### PR TITLE
docs: Remove unrelated browser caching section from troubleshooting

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -191,17 +191,6 @@ python rica_server.py --no-open
 
 **Solution**: Ensure you started the server from the tedana output directory.
 
-### Browser Shows Old Version After Update
-
-**Cause**: Browser cached a previous version of Rica.
-
-**Solutions**:
-
-1. **Hard refresh**: Press `Ctrl+Shift+R` (Windows/Linux) or `Cmd+Shift+R` (macOS)
-2. **Clear browser cache**: Clear cached files for localhost in your browser settings
-3. **Use a different browser**: Open the Rica URL in a browser that hasn't cached the old version
-4. **Use incognito/private mode**: Open the URL in a private browsing window
-
 ## Getting Help
 
 If your issue isn't covered here:


### PR DESCRIPTION
Address Copilot PR review feedback on PR #101. The browser caching troubleshooting documentation was added alongside the zoom fixes but is unrelated to the PR's main focus (scatter plot reference lines). Removing it to keep the PR focused on zoom behavior changes.

The browser caching documentation can be added in a separate PR.

https://claude.ai/code/session_01Hm2C92UgDt8W7xMXT2wJFm